### PR TITLE
enhancement: Add the ability to inject an "init file" at startup

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	cpuProfile *string
-	initFile   *string
 )
 
 // This is just a copy of all the flags from the testing package.
@@ -36,5 +35,4 @@ func initFlags() {
 	_ = flag.String("test.bench", "", "")
 	_ = flag.Bool("test.benchmem", false, "")
 	_ = flag.Duration("test.benchtime", time.Second, "")
-	initFile = flag.String("initFile", "", "")
 }

--- a/flags.go
+++ b/flags.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	cpuProfile *string
+	initFile   *string
 )
 
 // This is just a copy of all the flags from the testing package.
@@ -35,4 +36,5 @@ func initFlags() {
 	_ = flag.String("test.bench", "", "")
 	_ = flag.Bool("test.benchmem", false, "")
 	_ = flag.Duration("test.benchtime", time.Second, "")
+	initFile = flag.String("initFile", "", "")
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,8 @@ func main() {
 	}
 
 	// Setup web server.
-	handler, err := NewWASMServer(*initFile, wasmFile, filterCPUProfile(argsCopy[1:]), logger)
+	initFile := os.Getenv("WASM_INIT_FILE")
+	handler, err := NewWASMServer(initFile, wasmFile, filterCPUProfile(argsCopy[1:]), logger)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	// Setup web server.
-	handler, err := NewWASMServer(wasmFile, filterCPUProfile(argsCopy[1:]), logger)
+	handler, err := NewWASMServer(*initFile, wasmFile, filterCPUProfile(argsCopy[1:]), logger)
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
# Background
We are currently working on optimizing our browser client of 0x-mesh (repository here: https://github.com/0xProject/0x-mesh), and some of the optimizations that we have needed to consider consist of attaching Javascript code to the `window` object and using this Javascript in lieu of Go implementations.

It was previously impossible for us to run our tests using `wasmbrowsertest` for these changes without setting up the window object in Go using the `syscall/js` package. This did not follow the DRY design methodology and was much more difficult than simply injecting Javascript into the web page.

# Description
This pull request adds support for passing in a Javascript file to load in the `index.html` file that is used by `wasmbrowsertest` by using an environment variable called `WASM_INIT_FILE`.