### PR TITLE
fix: Cleanup Chrome on Failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,14 +25,15 @@ import (
 )
 
 func main() {
-	// NOTE(jalextowle): Since `os.Exit` will cause the process to exit, this defer
+	// NOTE: Since `os.Exit` will cause the process to exit, this defer
 	// must be at the bottom of the defer stack to allow all other defer calls to
-	// be called first. We pass this deferred function a pointer to an exit code
-	// so that it can be altered later in the program.
+	// be called first.
 	exitCode := 0
-	defer func(code *int) {
-		os.Exit(*code)
-	}(&exitCode)
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
 
 	logger := log.New(os.Stderr, "[wasmbrowsertest]: ", log.LstdFlags|log.Lshortfile)
 	if len(os.Args) < 2 {


### PR DESCRIPTION
# Description
I noticed a problem when I was running browser tests that failed with `wasmbrowsertest`. Large amounts of Chrome instances were being spun up, which was very taxing for my CPU. After some investigation, I came to the realization that these Chrome instances were being spun up by `wasmbrowsertest` and were not being torn down when a test suite failed. 

The root of the problem appears to be that `defer os.Exit($code)` will cause the program to exit immediately *without calling the defers that were defined previously in the file*. This behavior of `defer` is described in this blogpost: https://blog.golang.org/defer-panic-and-recover.