### PR TITLE
Add func to serve local file

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -87,6 +87,13 @@ func (ws *wasmServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if _, err := w.Write(ws.wasmExecJS); err != nil {
 			ws.logger.Println("unable to write wasm_exec.")
 		}
+	default:
+
+		if dir, err := os.Getwd(); err == nil {
+			f := path.Join(dir, r.URL.Path)
+			http.ServeFile(w, r, f)
+		}
+
 	}
 }
 


### PR DESCRIPTION
Hi agnivade,

I'm using this feature since month ago , but now , i really NEED it for the "worker services" test of hogosuru.

Case of test:

"When i want test worker services, i must install a dummy worker service js file". This file must be in the same domain (localhost) or must use an external https static files. It's weird to serve this file in another place than the repo himself.

Can you reevaluate your position on the subject?