### PR TITLE
Add test coverage support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agnivade/wasmbrowsertest
 
-go 1.12
+go 1.16
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20221108233440-fad8339618ab

--- a/handler.go
+++ b/handler.go
@@ -19,21 +19,23 @@ import (
 var indexHTML string
 
 type wasmServer struct {
-	indexTmpl  *template.Template
-	wasmFile   string
-	wasmExecJS []byte
-	args       []string
-	envMap     map[string]string
-	logger     *log.Logger
+	indexTmpl    *template.Template
+	wasmFile     string
+	wasmExecJS   []byte
+	args         []string
+	coverageFile string
+	envMap       map[string]string
+	logger       *log.Logger
 }
 
-func NewWASMServer(wasmFile string, args []string, l *log.Logger) (http.Handler, error) {
+func NewWASMServer(wasmFile string, args []string, coverageFile string, l *log.Logger) (http.Handler, error) {
 	var err error
 	srv := &wasmServer{
-		wasmFile: wasmFile,
-		args:     args,
-		logger:   l,
-		envMap:   make(map[string]string),
+		wasmFile:     wasmFile,
+		args:         args,
+		coverageFile: coverageFile,
+		logger:       l,
+		envMap:       make(map[string]string),
 	}
 
 	for _, env := range os.Environ() {
@@ -60,13 +62,15 @@ func (ws *wasmServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/", "/index.html":
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 		data := struct {
-			WASMFile string
-			Args     []string
-			EnvMap   map[string]string
+			WASMFile     string
+			Args         []string
+			CoverageFile string
+			EnvMap       map[string]string
 		}{
-			WASMFile: filepath.Base(ws.wasmFile),
-			Args:     ws.args,
-			EnvMap:   ws.envMap,
+			WASMFile:     filepath.Base(ws.wasmFile),
+			Args:         ws.args,
+			CoverageFile: ws.coverageFile,
+			EnvMap:       ws.envMap,
 		}
 		err := ws.indexTmpl.Execute(w, data)
 		if err != nil {

--- a/index.html
+++ b/index.html
@@ -30,9 +30,42 @@ license that can be found in the LICENSE file.
 		function goExit(code) {
 			exitCode = code;
 		}
+		function enosys() {
+			const err = new Error("not implemented");
+			err.code = "ENOSYS";
+			return err;
+		}
+		let coverageProfileContents;
 
 		(async() => {
 			const go = new Go();
+			const defaultWriteSync = window.fs.writeSync;
+			const coverFileDescriptor = 3; // 1 above standard descriptors (0-2)
+			const coverFilePath = {{.CoverageFile}};
+			window.fs.open = (path, flags, mode, callback) => {
+				if (path !== coverFilePath) {
+					callback(enosys());
+					return;
+				}
+				coverageProfileContents = "";
+				callback(null, coverFileDescriptor);
+			};
+			window.fs.close = (fd, callback) => {
+				if (fd !== coverFileDescriptor) {
+					callback(enosys());
+					return;
+				}
+				callback(null);
+			};
+			const decoder = new TextDecoder("utf-8");
+			window.fs.writeSync = (fd, buf) => {
+				if (fd === coverFileDescriptor) {
+					coverageProfileContents += decoder.decode(buf);
+					return buf.length;
+				}
+				return defaultWriteSync(fd, buf);
+			};
+
 			go.argv = [{{range $i, $item := .Args}} {{if $i}}, {{end}} "{{$item}}" {{end}}];
 			// The notFirst variable sets itself to true after first iteration. This is to put commas in between.
 			go.env = { {{ $notFirst := false }}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+Copyright 2018 The Go Authors. All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file.
+-->
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Go wasm</title>
+</head>
+
+<body>
+	<!--
+	Add the following polyfill for Microsoft Edge 17/18 support:
+	<script src="https://cdn.jsdelivr.net/npm/text-encoding@0.7.0/lib/encoding.min.js"></script>
+	(see https://caniuse.com/#feat=textencoder)
+	-->
+	<script src="wasm_exec.js"></script>
+	<script>
+		if (!WebAssembly.instantiateStreaming) { // polyfill
+			WebAssembly.instantiateStreaming = async (resp, importObject) => {
+				const source = await (await resp).arrayBuffer();
+				return await WebAssembly.instantiate(source, importObject);
+			};
+		}
+
+		let exitCode = 0;
+		function goExit(code) {
+			exitCode = code;
+		}
+
+		(async() => {
+			const go = new Go();
+			go.argv = [{{range $i, $item := .Args}} {{if $i}}, {{end}} "{{$item}}" {{end}}];
+			// The notFirst variable sets itself to true after first iteration. This is to put commas in between.
+			go.env = { {{ $notFirst := false }}
+			{{range $key, $val := .EnvMap}} {{if $notFirst}}, {{end}} {{$key}}: "{{$val}}" {{ $notFirst = true }}
+			{{end}} };
+			go.exit = goExit;
+			let mod, inst;
+			await WebAssembly.instantiateStreaming(fetch("{{.WASMFile}}"), go.importObject).then((result) => {
+				mod = result.module;
+				inst = result.instance;
+			}).catch((err) => {
+				console.error(err);
+			});
+			await go.run(inst);
+			document.getElementById("doneButton").disabled = false;
+		})();
+	</script>
+
+	<button id="doneButton" style="display: none;" disabled>Done</button>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,13 +36,11 @@ license that can be found in the LICENSE file.
 			return err;
 		}
 		let coverageProfileContents;
-
-		(async() => {
-			const go = new Go();
-			const defaultWriteSync = window.fs.writeSync;
+		function overrideFS(fs) {
+			const defaultWriteSync = globalThis.fs.writeSync;
 			const coverFileDescriptor = 3; // 1 above standard descriptors (0-2)
 			const coverFilePath = {{.CoverageFile}};
-			window.fs.open = (path, flags, mode, callback) => {
+			fs.open = (path, flags, mode, callback) => {
 				if (path !== coverFilePath) {
 					callback(enosys());
 					return;
@@ -50,22 +48,29 @@ license that can be found in the LICENSE file.
 				coverageProfileContents = "";
 				callback(null, coverFileDescriptor);
 			};
-			window.fs.close = (fd, callback) => {
+			fs.close = (fd, callback) => {
 				if (fd !== coverFileDescriptor) {
 					callback(enosys());
 					return;
 				}
 				callback(null);
 			};
+			if (!globalThis.TextDecoder) {
+				throw new Error("globalThis.TextDecoder is not available, polyfill required");
+			}
 			const decoder = new TextDecoder("utf-8");
-			window.fs.writeSync = (fd, buf) => {
+			fs.writeSync = (fd, buf) => {
 				if (fd === coverFileDescriptor) {
 					coverageProfileContents += decoder.decode(buf);
 					return buf.length;
 				}
 				return defaultWriteSync(fd, buf);
 			};
+		}
 
+		(async() => {
+			const go = new Go();
+			overrideFS(globalThis.fs)
 			go.argv = [{{range $i, $item := .Args}} {{if $i}}, {{end}} "{{$item}}" {{end}}];
 			// The notFirst variable sets itself to true after first iteration. This is to put commas in between.
 			go.env = { {{ $notFirst := false }}

--- a/index.html
+++ b/index.html
@@ -35,36 +35,41 @@ license that can be found in the LICENSE file.
 			err.code = "ENOSYS";
 			return err;
 		}
-		let coverageProfileContents;
+		let coverageProfileContents = "";
 		function overrideFS(fs) {
-			const defaultWriteSync = globalThis.fs.writeSync;
-			const coverFileDescriptor = 3; // 1 above standard descriptors (0-2)
+			// A typical runtime opens fd's in sequence above the standard descriptors (0-2).
+			// Choose an arbitrarily high fd for the custom coverage file to avoid conflict with the actual runtime fd's.
+			const coverFileDescriptor = Number.MAX_SAFE_INTEGER; 
 			const coverFilePath = {{.CoverageFile}};
+			// Wraps the default operations with bind() to ensure internal usage of 'this' continues to work.
+			const defaultOpen = fs.open.bind(fs);
 			fs.open = (path, flags, mode, callback) => {
-				if (path !== coverFilePath) {
-					callback(enosys());
+				if (path === coverFilePath) {
+					callback(null, coverFileDescriptor);
 					return;
 				}
-				coverageProfileContents = "";
-				callback(null, coverFileDescriptor);
+				defaultOpen(path, flags, mode, callback);
 			};
+			const defaultClose = fs.close.bind(fs);
 			fs.close = (fd, callback) => {
-				if (fd !== coverFileDescriptor) {
-					callback(enosys());
+				if (fd === coverFileDescriptor) {
+					callback(null);
 					return;
 				}
-				callback(null);
+				defaultClose(fd, callback);
 			};
 			if (!globalThis.TextDecoder) {
 				throw new Error("globalThis.TextDecoder is not available, polyfill required");
 			}
 			const decoder = new TextDecoder("utf-8");
-			fs.writeSync = (fd, buf) => {
+			const defaultWrite = fs.write.bind(fs);
+			fs.write = (fd, buf, offset, length, position, callback) => {
 				if (fd === coverFileDescriptor) {
 					coverageProfileContents += decoder.decode(buf);
-					return buf.length;
+					callback(null, buf.length);
+					return;
 				}
-				return defaultWriteSync(fd, buf);
+				defaultWrite(fd, buf, offset, length, position, callback);
 			};
 		}
 


### PR DESCRIPTION
Fixes https://github.com/agnivade/wasmbrowsertest/issues/5

I saw some discussion in #5 on the difficulty of collecting coverage without also changing upstream Go. I've managed to find a working solution with very minimal tweaks that works pretty well. I'm curious what you think.

Personally, I'll definitely be using something like this while working on [HackPad](https://github.com/hack-pad/hackpad) and related projects.

**How it works:**

This solution overrides three file system operations for the purposes of opening, writing, and closing only the coverage profile file. The file's contents are copied out of the JS runtime and written again to the real file.

I also bumped to Go 1.16 to use embedded files, but I definitely can revert that if it's not desired. It was mostly so I could make use of native JS file editing in my IDE 😄 