### PR TITLE
Add functional tests, fix unset exit codes on panics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Install cleanenv
       run: go install ./cmd/cleanenv
     - name: Test
-      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -- go test -v -race -timeout 2m ./...
+      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -- go test -v -race -timeout 5m ./...
     - name: Install
       run: go install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Install cleanenv
       run: go install ./cmd/cleanenv
     - name: Test
-      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -- go test -v -race ./...
+      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -- go test -v -race -timeout 2m ./...
     - name: Install
       run: go install

--- a/http_server.go
+++ b/http_server.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"time"
+)
+
+func startHTTPServer(ctx context.Context, handler http.Handler, logger *log.Logger) (url string, shutdown context.CancelFunc, err error) {
+	// Need to generate a random port every time for tests in parallel to run.
+	l, err := net.Listen("tcp", "localhost:")
+	if err != nil {
+		return "", nil, err
+	}
+
+	server := &http.Server{
+		Handler: handler,
+	}
+	go func() { // serves HTTP
+		err := server.Serve(l)
+		if err != http.ErrServerClosed {
+			logger.Println(err)
+		}
+	}()
+
+	shutdownCtx, shutdownNoWait := context.WithCancel(ctx)
+	shutdownComplete := make(chan struct{}, 1)
+	go func() { // waits for canceled ctx or triggered shutdown, then shuts down HTTP
+		<-shutdownCtx.Done()
+		shutdownTimeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := server.Shutdown(shutdownTimeoutCtx)
+		if err != nil {
+			logger.Println(err)
+		}
+		shutdownComplete <- struct{}{}
+	}()
+
+	shutdown = func() {
+		shutdownNoWait()
+		<-shutdownComplete
+	}
+	url = (&neturl.URL{
+		Scheme: "http",
+		Host:   l.Addr().String(),
+	}).String()
+	return url, shutdown, nil
+}

--- a/http_server.go
+++ b/http_server.go
@@ -26,7 +26,7 @@ func startHTTPServer(ctx context.Context, handler http.Handler, logger *log.Logg
 		}
 	}()
 
-	shutdownCtx, shutdownNoWait := context.WithCancel(ctx)
+	shutdownCtx, startShutdown := context.WithCancel(ctx)
 	shutdownComplete := make(chan struct{}, 1)
 	go func() { // waits for canceled ctx or triggered shutdown, then shuts down HTTP
 		<-shutdownCtx.Done()
@@ -40,7 +40,7 @@ func startHTTPServer(ctx context.Context, handler http.Handler, logger *log.Logg
 	}()
 
 	shutdown = func() {
-		shutdownNoWait()
+		startShutdown()
 		<-shutdownComplete
 	}
 	url = (&neturl.URL{

--- a/index.html
+++ b/index.html
@@ -89,7 +89,12 @@ license that can be found in the LICENSE file.
 			}).catch((err) => {
 				console.error(err);
 			});
-			await go.run(inst);
+			try {
+				await go.run(inst);
+			} catch(e) {
+				exitCode = 1
+				console.error(e)
+			}
 			document.getElementById("doneButton").disabled = false;
 		})();
 	</script>

--- a/main.go
+++ b/main.go
@@ -175,6 +175,8 @@ func run(args []string, errOutput io.Writer, flagSet *flag.FlagSet) (exitCode in
 
 	err = chromedp.Run(ctx, tasks...)
 	if err != nil {
+		// Browser did not exit cleanly. Likely failed with an uncaught error.
+		exitCode = 1
 		logger.Println(err)
 	}
 	if exitCode != 0 {

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func run(args []string, errOutput io.Writer, flagSet *flag.FlagSet) (exitCode in
 
 	done := make(chan struct{})
 	go func() {
-		err = httpServer.Serve(l)
+		err := httpServer.Serve(l)
 		if err != http.ErrServerClosed {
 			logger.Println(err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -151,12 +151,10 @@ func (w *testWriter) Write(b []byte) (int, error) {
 func testRun(t *testing.T, wasmFile string, flags ...string) ([]byte, int) {
 	var logs bytes.Buffer
 	output := io.MultiWriter(testLogger(t), &logs)
-	exitCode := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, testFlagSet(t))
-	return logs.Bytes(), exitCode
-}
+	flagSet := flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
 
-func testFlagSet(t *testing.T) *flag.FlagSet {
-	return flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
+	exitCode := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, flagSet)
+	return logs.Bytes(), exitCode
 }
 
 // writeFile creates a file at $baseDir/$path with the given contents, where 'path' is slash separated

--- a/main_test.go
+++ b/main_test.go
@@ -10,66 +10,6 @@ import (
 	"testing"
 )
 
-func testRun(t *testing.T, wasmFile string, flags ...string) ([]byte, int) {
-	var logs bytes.Buffer
-	output := io.MultiWriter(testLogger(t), &logs)
-	exitCode := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, testFlagSet(t))
-	return logs.Bytes(), exitCode
-}
-
-func testFlagSet(t *testing.T) *flag.FlagSet {
-	return flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
-}
-
-type testWriter struct {
-	testingT *testing.T
-}
-
-func testLogger(t *testing.T) io.Writer {
-	return &testWriter{t}
-}
-
-func (w *testWriter) Write(b []byte) (int, error) {
-	w.testingT.Helper()
-	w.testingT.Log(string(b))
-	return len(b), nil
-}
-
-// writeFile creates a file at $baseDir/$path with the given contents, where 'path' is slash separated
-func writeFile(t *testing.T, baseDir, path, contents string) {
-	t.Helper()
-	path = filepath.FromSlash(path)
-	fullPath := filepath.Join(baseDir, path)
-	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
-	if err != nil {
-		t.Fatal("Failed to create file's base directory:", err)
-	}
-	err = os.WriteFile(fullPath, []byte(contents), 0600)
-	if err != nil {
-		t.Fatal("Failed to create file:", err)
-	}
-}
-
-// buildTestWasm builds the given Go package's test binary and returns the output Wasm file
-func buildTestWasm(t *testing.T, path string) string {
-	t.Helper()
-	outputFile := filepath.Join(t.TempDir(), "out.wasm")
-	cmd := exec.Command("go", "test", "-c", "-o", outputFile, ".")
-	cmd.Dir = path
-	cmd.Env = append(os.Environ(),
-		"GOOS=js",
-		"GOARCH=wasm",
-	)
-	output, err := cmd.CombinedOutput()
-	if len(output) > 0 {
-		t.Log(string(output))
-	}
-	if err != nil {
-		t.Fatal("Failed to build Wasm binary:", err)
-	}
-	return outputFile
-}
-
 func TestRunPassing(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -191,4 +131,64 @@ func TestFooNextEventLoopPanic(t *testing.T) {
 	if exitCode != 1 {
 		t.Errorf("Test run should fail, got exit code %d", exitCode)
 	}
+}
+
+type testWriter struct {
+	testingT *testing.T
+}
+
+func testLogger(t *testing.T) io.Writer {
+	return &testWriter{t}
+}
+
+func (w *testWriter) Write(b []byte) (int, error) {
+	w.testingT.Helper()
+	w.testingT.Log(string(b))
+	return len(b), nil
+}
+
+func testRun(t *testing.T, wasmFile string, flags ...string) ([]byte, int) {
+	var logs bytes.Buffer
+	output := io.MultiWriter(testLogger(t), &logs)
+	exitCode := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, testFlagSet(t))
+	return logs.Bytes(), exitCode
+}
+
+func testFlagSet(t *testing.T) *flag.FlagSet {
+	return flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
+}
+
+// writeFile creates a file at $baseDir/$path with the given contents, where 'path' is slash separated
+func writeFile(t *testing.T, baseDir, path, contents string) {
+	t.Helper()
+	path = filepath.FromSlash(path)
+	fullPath := filepath.Join(baseDir, path)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	if err != nil {
+		t.Fatal("Failed to create file's base directory:", err)
+	}
+	err = os.WriteFile(fullPath, []byte(contents), 0600)
+	if err != nil {
+		t.Fatal("Failed to create file:", err)
+	}
+}
+
+// buildTestWasm builds the given Go package's test binary and returns the output Wasm file
+func buildTestWasm(t *testing.T, path string) string {
+	t.Helper()
+	outputFile := filepath.Join(t.TempDir(), "out.wasm")
+	cmd := exec.Command("go", "test", "-c", "-o", outputFile, ".")
+	cmd.Dir = path
+	cmd.Env = append(os.Environ(),
+		"GOOS=js",
+		"GOARCH=wasm",
+	)
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		t.Log(string(output))
+	}
+	if err != nil {
+		t.Fatal("Failed to build Wasm binary:", err)
+	}
+	return outputFile
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"io"
 	"os"
@@ -149,8 +150,10 @@ func testRun(t *testing.T, wasmFile string, flags ...string) ([]byte, error) {
 	var logs bytes.Buffer
 	output := io.MultiWriter(testLogger(t), &logs)
 	flagSet := flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
-	err := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, flagSet)
+	err := run(ctx, append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, flagSet)
 	return logs.Bytes(), err
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func testRun(t *testing.T, wasmFile string, flags ...string) ([]byte, int) {
+	var logs bytes.Buffer
+	output := io.MultiWriter(testLogger(t), &logs)
+	exitCode := run(append([]string{"go_js_wasm_exec", wasmFile, "-test.v"}, flags...), output, testFlagSet(t))
+	return logs.Bytes(), exitCode
+}
+
+func testFlagSet(t *testing.T) *flag.FlagSet {
+	return flag.NewFlagSet("wasmbrowsertest", flag.ContinueOnError)
+}
+
+type testWriter struct {
+	testingT *testing.T
+}
+
+func testLogger(t *testing.T) io.Writer {
+	return &testWriter{t}
+}
+
+func (w *testWriter) Write(b []byte) (int, error) {
+	w.testingT.Helper()
+	w.testingT.Log(string(b))
+	return len(b), nil
+}
+
+// writeFile creates a file at $baseDir/$path with the given contents, where 'path' is slash separated
+func writeFile(t *testing.T, baseDir, path, contents string) {
+	t.Helper()
+	path = filepath.FromSlash(path)
+	fullPath := filepath.Join(baseDir, path)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	if err != nil {
+		t.Fatal("Failed to create file's base directory:", err)
+	}
+	err = os.WriteFile(fullPath, []byte(contents), 0600)
+	if err != nil {
+		t.Fatal("Failed to create file:", err)
+	}
+}
+
+// buildTestWasm builds the given Go package's test binary and returns the output Wasm file
+func buildTestWasm(t *testing.T, path string) string {
+	t.Helper()
+	outputFile := filepath.Join(t.TempDir(), "out.wasm")
+	cmd := exec.Command("go", "test", "-c", "-o", outputFile, ".")
+	cmd.Dir = path
+	cmd.Env = append(os.Environ(),
+		"GOOS=js",
+		"GOARCH=wasm",
+	)
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		t.Log(string(output))
+	}
+	if err != nil {
+		t.Fatal("Failed to build Wasm binary:", err)
+	}
+	return outputFile
+}
+
+func TestRunPassing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", `
+module foo
+`)
+	writeFile(t, dir, "foo_test.go", `
+package foo
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+	if false {
+		t.Errorf("foo failed")
+	}
+}
+`)
+	wasmFile := buildTestWasm(t, dir)
+
+	_, exitCode := testRun(t, wasmFile, "-test.v")
+	if exitCode != 0 {
+		t.Errorf("Test run should pass, got exit code %d", exitCode)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -4,16 +4,15 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 )
 
 // gentleParse takes a flag.FlagSet, calls Parse to get its flags parsed,
 // and collects the arguments the FlagSet does not recognize, returning
 // the collected list.
-func gentleParse(flagset *flag.FlagSet, args []string) []string {
+func gentleParse(flagset *flag.FlagSet, args []string) ([]string, error) {
 	if len(args) == 0 {
-		return nil
+		return nil, nil
 	}
 	const prefix = "flag provided but not defined: "
 
@@ -48,7 +47,7 @@ func gentleParse(flagset *flag.FlagSet, args []string) []string {
 			fmt.Fprintf(w, "%s\n", err)
 			flagset.SetOutput(w)
 			flagset.Usage()
-			os.Exit(1)
+			return nil, err
 		}
 
 		// Check if the call to flagset.Parse ate a "--". If so, we're done
@@ -58,10 +57,10 @@ func gentleParse(flagset *flag.FlagSet, args []string) []string {
 			lastabsorbed := next[lastabsorbedpos]
 			if lastabsorbed == "--" {
 				r = append(r, "--") // return the "--" too.
-				return append(r, flagset.Args()...)
+				return append(r, flagset.Args()...), nil
 			}
 		}
 		next = flagset.Args()
 	}
-	return r
+	return r, nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -24,14 +24,14 @@ func TestParse(t *testing.T) {
 
 	t.Run("Other", func(t *testing.T) {
 		// Empty in, empty out, with an extra `other` variable that has a default.
-		testParseOther().Expect(t,
+		testParseOther(t).Expect(t,
 			`cpuProfile: ""`,
 			`other     : "default-other-value"`,
 			`passon    : []`,
 		)
 
 		// Test parsing of a custom flag with a custom value
-		testParseOther("-test.v", "-test.cpuprofile", "cpu1.out", "-other=another").Expect(t,
+		testParseOther(t, "-test.v", "-test.cpuprofile", "cpu1.out", "-other=another").Expect(t,
 			`cpuProfile: "cpu1.out"`,
 			`other     : "another"`,
 			`passon    : ["-test.v"]`,
@@ -199,7 +199,8 @@ func testParse(t *testing.T, args ...string) testParseGot {
 // This one acts more like an example of how to perform a different type of test.
 // It was perhaps useful in early stages of building unit tests but then seems
 // to have gone unused except for the default, empty, case.
-func testParseOther(args ...string) testParseGot {
+func testParseOther(t *testing.T, args ...string) testParseGot {
+	t.Helper()
 	var (
 		cpuProfile string
 		other      string
@@ -213,7 +214,7 @@ func testParseOther(args ...string) testParseGot {
 
 	passon, err := gentleParse(flagset, args)
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
 
 	return makeParseGot(

--- a/parse_test.go
+++ b/parse_test.go
@@ -184,7 +184,10 @@ func testParse(args ...string) testParseGot {
 
 	flagset.StringVar(&cpuProfile, "test.cpuprofile", "", "")
 
-	passon := gentleParse(flagset, args)
+	passon, err := gentleParse(flagset, args)
+	if err != nil {
+		panic(err)
+	}
 
 	return makeParseGot(
 		fmt.Sprintf("cpuProfile: %q", cpuProfile),
@@ -207,7 +210,10 @@ func testParseOther(args ...string) testParseGot {
 	flagset.StringVar(&cpuProfile, "test.cpuprofile", "", "")
 	flagset.StringVar(&other, "other", "default-other-value", "")
 
-	passon := gentleParse(flagset, args)
+	passon, err := gentleParse(flagset, args)
+	if err != nil {
+		panic(err)
+	}
 
 	return makeParseGot(
 		fmt.Sprintf("cpuProfile: %q", cpuProfile),

--- a/parse_test.go
+++ b/parse_test.go
@@ -16,7 +16,7 @@ import (
 func TestParse(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		// Empty in, empty out.
-		testParse().Expect(t,
+		testParse(t).Expect(t,
 			`cpuProfile: ""`,
 			`passon    : []`,
 		)
@@ -40,7 +40,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("Verbose", func(t *testing.T) {
 		// One unrecognized in, same out.
-		testParse("-test.v").Expect(t,
+		testParse(t, "-test.v").Expect(t,
 			`cpuProfile: ""`,
 			`passon    : ["-test.v"]`,
 		)
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("CPU1", func(t *testing.T) {
 		// One unrecognized followed by ours.
-		testParse("-test.v", "-test.cpuprofile", "cpu1.out").Expect(t,
+		testParse(t, "-test.v", "-test.cpuprofile", "cpu1.out").Expect(t,
 			`cpuProfile: "cpu1.out"`,
 			`passon    : ["-test.v"]`,
 		)
@@ -56,7 +56,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("CPU2", func(t *testing.T) {
 		// Ours followed by one unrecognized.
-		testParse("-test.cpuprofile", "cpu2.out", "-test.v").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu2.out", "-test.v").Expect(t,
 			`cpuProfile: "cpu2.out"`,
 			`passon    : ["-test.v"]`,
 		)
@@ -64,7 +64,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("CPU3", func(t *testing.T) {
 		// Ours followed by one unrecognized that uses "=".
-		testParse("-test.cpuprofile", "cpu3.out", "-test.v=true").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu3.out", "-test.v=true").Expect(t,
 			`cpuProfile: "cpu3.out"`,
 			`passon    : ["-test.v=true"]`,
 		)
@@ -72,7 +72,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("EqualCPU4", func(t *testing.T) {
 		// Swapping order from Cpu3 test, the unrecognized first, followed by ours.
-		testParse("-test.v=true", "-test.cpuprofile", "cpu4.out").Expect(t,
+		testParse(t, "-test.v=true", "-test.cpuprofile", "cpu4.out").Expect(t,
 			`cpuProfile: "cpu4.out"`,
 			`passon    : ["-test.v=true"]`,
 		)
@@ -80,7 +80,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("ExtraBool1", func(t *testing.T) {
 		// Ours followed by two unrecognized.
-		testParse("-test.cpuprofile", "cpu.out", "-test.v", "-bool").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu.out", "-test.v", "-bool").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["-test.v" "-bool"]`,
 		)
@@ -88,7 +88,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("ExtraBool2", func(t *testing.T) {
 		// Ours between two unrecognized.
-		testParse("-bool", "-test.cpuprofile", "cpu.out", "-test.v").Expect(t,
+		testParse(t, "-bool", "-test.cpuprofile", "cpu.out", "-test.v").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["-bool" "-test.v"]`,
 		)
@@ -96,7 +96,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("ExtraStringNoDDash1", func(t *testing.T) {
 		// Ours pulled out from front.
-		testParse("-test.cpuprofile", "cpu.out", "-test.v", "-bool", "-string", "last").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu.out", "-test.v", "-bool", "-string", "last").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["-test.v" "-bool" "-string" "last"]`,
 		)
@@ -104,7 +104,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("ExtraStringNoDDash2", func(t *testing.T) {
 		// Ours pulled out from middle.
-		testParse("-string", "first", "-test.cpuprofile", "cpu.out", "-test.v", "-bool").Expect(t,
+		testParse(t, "-string", "first", "-test.cpuprofile", "cpu.out", "-test.v", "-bool").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["-string" "first" "-test.v" "-bool"]`,
 		)
@@ -112,7 +112,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("DDash1ExtraString", func(t *testing.T) {
 		// Ours pulled out from front and the -- appears afterwards.
-		testParse("-test.cpuprofile", "cpu.out", "-test.v", "--", "-bool", "-string", "abc").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu.out", "-test.v", "--", "-bool", "-string", "abc").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["-test.v" "--" "-bool" "-string" "abc"]`,
 		)
@@ -120,7 +120,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("DDash2ExtraString", func(t *testing.T) {
 		// Ours pulled out from front and the -- appears afterwards.
-		testParse("-test.cpuprofile", "cpu.out", "--", "-test.v", "-bool", "-string", "abc").Expect(t,
+		testParse(t, "-test.cpuprofile", "cpu.out", "--", "-test.v", "-bool", "-string", "abc").Expect(t,
 			`cpuProfile: "cpu.out"`,
 			`passon    : ["--" "-test.v" "-bool" "-string" "abc"]`,
 		)
@@ -128,7 +128,7 @@ func TestParse(t *testing.T) {
 
 	t.Run("DDash3UnprocessedProfile", func(t *testing.T) {
 		// Ours *not* pulled out because it appears after a --, just as "go test" would handle it.
-		testParse("--", "-test.cpuprofile", "cpu.other", "-test.v", "-bool", "-string", "abc").Expect(t,
+		testParse(t, "--", "-test.cpuprofile", "cpu.other", "-test.v", "-bool", "-string", "abc").Expect(t,
 			`cpuProfile: ""`,
 			`passon    : ["--" "-test.cpuprofile" "cpu.other" "-test.v" "-bool" "-string" "abc"]`,
 		)
@@ -174,7 +174,8 @@ func (g testParseGot) Expect(t testing.TB, expect ...string) {
 	}
 }
 
-func testParse(args ...string) testParseGot {
+func testParse(t *testing.T, args ...string) testParseGot {
+	t.Helper()
 	var (
 		cpuProfile string
 	)
@@ -186,7 +187,7 @@ func testParse(args ...string) testParseGot {
 
 	passon, err := gentleParse(flagset, args)
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
 
 	return makeParseGot(


### PR DESCRIPTION

I ran into a few panics in my projects and realized those triggered package failures but were "passing" the tests because they exited with 0.

This PR fixes those exit codes so it doesn't miss anything.

I had difficulty reproducing the failures for a while, which necessitated this new functional test style. I hope it is to your liking! 😄

* Refactor to support functional tests
* Fix unset exit code from uncaught exception
* Fix unset exit code for panic in next tick of event loop
