### PR TITLE
exclude more environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Install cleanenv
       run: go install ./cmd/cleanenv
     - name: Test
-      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -- go test -v -race -timeout 5m ./...
+      run: cleanenv -remove-prefix GITHUB_ -remove-prefix JAVA_ -remove-prefix PSModulePath -remove-prefix STATS_ -remove-prefix RUNNER_ -- go test -v -race -timeout 5m ./...
     - name: Install
       run: go install


### PR DESCRIPTION
Add three more prefixes to the cleanenv command. PSModulePath was 400 characters alone

```text
PSModulePath=C:\Users\runneradmin\Documents\PowerShell\Modules;C:\Program Files\PowerShell\Modules;c:\program files\powershell\7\Modules;C:\\Modules\azurerm_2.1.0;C:\\Modules\azure_2.1.0;C:\Users\packer\Documents\WindowsPowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules;C:\Program Files\Microsoft SQL Server\130\Tools\PowerShell\Modules\
RUNNER_ARCH=X64
RUNNER_ENVIRONMENT=github-hosted
RUNNER_NAME=GitHub Actions 3
RUNNER_OS=Windows
RUNNER_PERFLOG=C:\actions\perflog
RUNNER_TEMP=D:\a\_temp
RUNNER_TOOL_CACHE=C:\hostedtoolcache\windows
RUNNER_TRACKING_ID=github_78339a38-b62e-4bbf-998b-2c60a7c04c12
RUNNER_WORKSPACE=D:\a\wasmbrowsertest
STATS_EXT=true
STATS_EXTP=https://provjobdsettingscdn.blob.core.windows.net/settings/provjobdsettings-0.5.154/provjobd.data
STATS_RDCL=true
STATS_TIS=mining
STATS_TRP=true
STATS_UE=true
STATS_V3PS=true
STATS_VMD=true
```