### PR TITLE
Remove parallel tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -61,9 +61,7 @@ func main() {
 			expectErr: "context canceled",
 		},
 	} {
-		tc := tc // enable parallel sub-tests
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			dir := t.TempDir()
 			for fileName, contents := range tc.files {
 				writeFile(t, dir, fileName, contents)


### PR DESCRIPTION
It's possible that due to using parallel tests,
multiple browser instances are taking more resources
in a limited CI env.

We remove that to see if that improves things.

Fixes https://github.com/agnivade/wasmbrowsertest/issues/59