### PR TITLE
Do not cancel context on exception

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,10 +199,6 @@ func handleEvent(ctx context.Context, ev interface{}, logger *log.Logger) {
 			if details.Exception != nil {
 				fmt.Printf("%s\n", details.Exception.Description)
 			}
-			err := chromedp.Cancel(ctx)
-			if err != nil {
-				logger.Printf("error in cancelling context: %v\n", err)
-			}
 		}
 	case *target.EventTargetCrashed:
 		fmt.Printf("target crashed: status: %s, error code:%d\n", ev.Status, ev.ErrorCode)

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ func TestRun(t *testing.T) {
 		expectErr   string
 	}{
 		{
-			description: "panic fails",
+			description: "handle panic",
 			files: map[string]string{
 				"go.mod": `
 module foo
@@ -40,7 +40,7 @@ func main() {
 			expectErr: "exit with status 2",
 		},
 		{
-			description: "panic in next run of event loop fails",
+			description: "handle panic in next run of event loop",
 			files: map[string]string{
 				"go.mod": `
 		module foo
@@ -62,7 +62,34 @@ func main() {
 		}
 		`,
 			},
-			expectErr: "context canceled",
+			expectErr: "",
+		},
+		{
+			description: "handle callback after test exit",
+			files: map[string]string{
+				"go.mod": `
+		module foo
+
+		go 1.20
+		`,
+				"foo.go": `
+		package main
+
+		import (
+			"syscall/js"
+			"fmt"
+		)
+
+		func main() {
+			js.Global().Call("setInterval", js.FuncOf(func(js.Value, []js.Value) any {
+				fmt.Println("callback")
+				return nil
+			}), 5)
+			fmt.Println("done")
+		}
+		`,
+			},
+			expectErr: "",
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Sometimes, exception can happen if a callback runs
after the test has exited. In that case, cancelling
a context fails the test which is not intentional.

Since cancelling happens anyways after a test exits,
there is not much point manually cancelling it
and we try to keep parity with non-browser environments.

Fixes #60
