### PR TITLE
Add WASM_NO_SANDBOX env to disable Chrome sandbox

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,11 @@ func run(ctx context.Context, args []string, errOutput io.Writer, flagSet *flag.
 			chromedp.Flag("headless", false),
 		)
 	}
+	if os.Getenv("WASM_NO_SANDBOX") == "on" {
+		opts = append(opts,
+			chromedp.NoSandbox,
+		)
+	}
 
 	// WSL needs the GPU disabled. See issue #10
 	if runtime.GOOS == "linux" && isWSL() {


### PR DESCRIPTION
On GitHub Actions (and similar CI environments), Chrome often fails to launch due to its sandbox being unavailable, resulting in the error: "No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces..."

This commit adds support for a new environment variable, `WASM_NO_SANDBOX`, which, when set to "on", appends `chromedp.NoSandbox` to the Chrome options. This allows Chrome to run without a sandbox and avoids the crash in CI pipelines that lack the necessary permissions or configurations for the standard Chrome sandbox.