### PR TITLE
chore: add debug output flag for browser startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,13 @@ func run(ctx context.Context, args []string, errOutput io.Writer, flagSet *flag.
 		)
 	}
 
+	// Forward the browser's own stdout/stderr
+	// so that startup failures (e.g. websocket timeout reached)
+	// leave some trace of what the browser was doing.
+	if os.Getenv("WASM_BROWSER_OUTPUT") == "on" {
+		opts = append(opts, chromedp.CombinedOutput(errOutput))
+	}
+
 	// create chrome instance
 	allocCtx, cancelAllocCtx := chromedp.NewExecAllocator(ctx, opts...)
 	defer cancelAllocCtx()


### PR DESCRIPTION
## Description
We've been getting a lot of `websocket url timeout reached` errors in CI, without a lot of sense of what might be causing them. The hope is that if we get access to the browser's stderr/stdout, we can see something that indicates what the issue is and figure it out in our runner.

## Change
* Add a new flag under `WASM_BROWSER_OUTPUT` that sends browser stderr/stdout to the error output
## Testing
Review.